### PR TITLE
refactor: default to docker dev env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,24 +5,24 @@ install:
 	go mod download
 	cd web && bash -c "source ~/.nvm/nvm.sh && pnpm install"
 
-dev-frontend:
+dev-frontend-bare:
 	cd web && bash -c "source ~/.nvm/nvm.sh && pnpm run dev"
 
-dev-backend:
+dev-backend-bare:
 	GO_ENV=development reflex -r '\.go$$' -s -- go run ./main.go -c config.yaml
 
 
-dev-backend-debug:
+dev-backend-debug-bare:
 	GO_ENV=development reflex -r '\.go$$' -s -- dlv debug --headless --listen=:2345 --api-version=2 --accept-multiclient ./main.go -- -c config.yaml
 
-dev:
+dev-bare:
 	@echo "Starting development servers..."
 	@trap 'kill 0' INT TERM EXIT; \
 	($(MAKE) dev-backend) & \
 	($(MAKE) dev-frontend) & \
 	wait
 
-dev-debug:
+dev-debug-bare:
 	@echo "Starting development servers with debug..."
 	@trap 'kill 0' INT TERM EXIT; \
 	($(MAKE) dev-backend-debug) & \
@@ -33,23 +33,23 @@ build:
 	docker build -t dashboard-site:latest -f docker/Dockerfile .
 
 # Docker development commands
-dev-docker:
+dev:
 	@echo "Starting Docker development environment..."
 	cd docker && docker compose up --build
 
-dev-docker-debug:
+dev-debug:
 	@echo "Starting Docker development environment with debugger..."
 	cd docker && docker compose run --rm --service-ports dashboard-app /usr/local/bin/start-debug.sh
 
-dev-docker-down:
+dev-stop:
 	@echo "Stopping Docker development environment..."
 	cd docker && docker compose down
 
-dev-docker-logs:
+dev-logs:
 	@echo "Following Docker development logs..."
 	cd docker && docker compose logs -f
 
-dev-docker-rebuild:
+dev-rebuild:
 	@echo "Rebuilding Docker development environment..."
 	cd docker && docker compose down && docker compose up --build
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added consolidated development commands: dev (starts backend + frontend) and dev-debug (with debugger).
  * Introduced user-facing aliases replacing Docker-prefixed commands: dev-stop, dev-logs, dev-rebuild.
  * Renamed legacy standalone targets with a -bare suffix for backend and frontend workflows.
  * No functional changes to underlying processes; adjustments are limited to naming and wrapper targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->