### PR TITLE
ci: only build on main and manual prod

### DIFF
--- a/.github/workflows/backend.yaml
+++ b/.github/workflows/backend.yaml
@@ -1,4 +1,4 @@
-name: 'Backend'
+name: 'Testing and Test Coverage'
 on:
   pull_request: {}
   push:

--- a/.github/workflows/build-latest.yaml
+++ b/.github/workflows/build-latest.yaml
@@ -1,0 +1,51 @@
+name: Build and Push Latest
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+    steps:
+      - name: 'Harden Runner'
+        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        with:
+          egress-policy: 'audit'
+
+      - name: 'Checkout'
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Extract Metadata
+        id: meta
+        uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f # v5.8.0
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=ref,event=branch
+            type=sha,format=long
+
+      - name: Login to Registry
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6
+        with:
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          annotations: ${{ steps.meta.outputs.annotations }}
+          provenance: true
+          sbom: true

--- a/.github/workflows/build-prod.yaml
+++ b/.github/workflows/build-prod.yaml
@@ -1,10 +1,12 @@
-name: Build and Push Docker Image
+name: Build Production Image
 
 on:
-  push:
-    branches:
-      - main
-  pull_request: {}
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Production tag (e.g., v1.0.0 or prod)'
+        required: false
+        default: 'prod'
 
 jobs:
   build:
@@ -25,12 +27,13 @@ jobs:
 
       - name: Extract Metadata
         id: meta
-        uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f
+        uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f # v5.8.0
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
-            type=ref,event=branch
-            type=ref,event=pr
+            type=raw,value=${{ inputs.tag }}
+            type=sha,format=long
+            type=raw,value=latest
 
       - name: Login to Registry
         uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0

--- a/.github/workflows/clean-tags.yaml
+++ b/.github/workflows/clean-tags.yaml
@@ -4,8 +4,6 @@ on:
   schedule:
     - cron: '0 2 * * *'  # Daily at 2 AM
   workflow_dispatch:
-  pull_request:
-    types: [closed]
 
 permissions:
   packages: write
@@ -19,6 +17,7 @@ jobs:
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
         with:
           egress-policy: 'audit'
+
       - name: Delete untagged versions
         uses: actions/delete-package-versions@e5bc658cc4c965c472efe991f8beea3981499c55 # v5.0.0
         with:
@@ -27,38 +26,19 @@ jobs:
           delete-only-untagged-versions: 'true'
           token: ${{ secrets.GITHUB_TOKEN }}
 
-  cleanup-closed-pr:
-    name: Delete package for closed PR
+  cleanup-old-shas:
+    name: Delete old SHA tags (keep last 30)
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.action == 'merged'
     steps:
       - name: 'Harden Runner'
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
         with:
           egress-policy: 'audit'
-      - name: Delete closed PR package
+      - name: Delete old SHA versions
         uses: actions/delete-package-versions@e5bc658cc4c965c472efe991f8beea3981499c55 # v5.0.0
         with:
           package-name: ${{ github.event.repository.name }}
           package-type: 'container'
-          ignore-versions: '^(?!pr-${{ github.event.pull_request.number }}$).*'
-          num-old-versions-to-delete: 1
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-  cleanup-old-prs:
-    name: Delete PR packages older than 30 days
-    runs-on: ubuntu-latest
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    steps:
-      - name: 'Harden Runner'
-        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
-        with:
-          egress-policy: 'audit'
-      - name: Delete old PR versions
-        uses: actions/delete-package-versions@e5bc658cc4c965c472efe991f8beea3981499c55 # v5.0.0
-        with:
-          package-name: ${{ github.event.repository.name }}
-          package-type: 'container'
-          min-versions-to-keep: 10
-          ignore-versions: '^main$'
+          min-versions-to-keep: 30
+          ignore-versions: '^(main|prod|latest)$'
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -16,8 +16,7 @@ name: "CodeQL"
 on:
   push:
     branches:
-      - master
-      - gh-pages
+      - main
     paths:
       - 'go.mod'
       - 'go.sum'
@@ -31,7 +30,7 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches:
-      - master
+      - main
     paths:
       - 'go.mod'
       - 'go.sum'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a manual workflow to build and push a production Docker image with provenance and SBOM.

- Chores
  - Renamed CI workflows for clearer purpose and visibility.
  - Updated triggers and branch targets to align with main and latest conventions.
  - Improved Docker image tagging strategy (including SHA-based tags) and metadata.
  - Revised tag cleanup to focus on SHA-based retention, expanded protected tags, and increased kept versions from 10 to 30.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->