### PR TITLE
feat: add redis sentinel support

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -107,7 +107,7 @@ redis:
     enabled: false
 
 deployment:
-  replicas: 1
+  replicas: 3
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -221,6 +221,10 @@ config:
       host: 0.0.0.0
       port: 9000
 
+  distributed:
+    enabled: true
+    ttl: '30s'
+
   redis:
     address: 'dashboard-redis.dashboard-site.svc.cluster.local:6379'
     session_index: 0
@@ -245,12 +249,12 @@ config:
     maxAge: 300
 
   session:
-    store: 'memory'
-    duration_source: 'fixed'
+    store: 'redis'
+    duration_source: 'oidc_tokens'
     secure: false
 
   cache:
-    type: 'memory'
+    type: 'redis'
 
   oidc:
     scopes:

--- a/internal/data/redis_cache_provider.go
+++ b/internal/data/redis_cache_provider.go
@@ -17,7 +17,7 @@ import (
 	"github.com/redis/go-redis/v9"
 )
 
-type RedisClient interface {
+type RedisCacheClient interface {
 	Get(ctx context.Context, key string) *redis.StringCmd
 	Set(ctx context.Context, key string, value interface{}, expiration time.Duration) *redis.StatusCmd
 	Del(ctx context.Context, keys ...string) *redis.IntCmd
@@ -28,13 +28,13 @@ type RedisClient interface {
 }
 
 type RedisCache struct {
-	client RedisClient
+	client RedisCacheClient
 	logger *slog.Logger
 }
 
 // NewRedisCache creates a new Redis-backed cache
 func NewRedisCache(cfg *config.Config, logger *slog.Logger) (*RedisCache, error) {
-	var client RedisClient
+	var client RedisCacheClient
 
 	if cfg.Redis.Sentinel != nil {
 		logger.Info("connecting to redis via sentinel",
@@ -57,7 +57,6 @@ func NewRedisCache(cfg *config.Config, logger *slog.Logger) (*RedisCache, error)
 			DB:           cfg.Redis.CacheIndex,
 			MinIdleConns: 2,
 		})
-
 	}
 
 	if cfg.Server.Debug != nil && cfg.Server.Debug.Enabled {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scales default deployment to 3 replicas for higher availability.
  * Enables distributed mode with a 30s TTL for coordination.
  * Moves sessions and cache from in-memory to Redis for persistence and reliability.
  * Derives session duration from OIDC tokens for more accurate expirations.
  * Adds Redis Sentinel support for automatic failover and improved observability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->